### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ jobs:
     name: versioning
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@master
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch

--- a/examples/RDS-starter/module.host.tf
+++ b/examples/RDS-starter/module.host.tf
@@ -1,4 +1,3 @@
 module "host" {
-  source  = "JamesWoolfenden/ip/http"
-  version = "0.2.7"
+  source = "JamesWoolfenden/ip/http"
 }

--- a/examples/RDS-starter/terraform.tf
+++ b/examples/RDS-starter/terraform.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
     http = {
-      version = "2.0.0"
       source  = "hashicorp/http"
+      version = "3.5.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/aws_alb/terraform.tf
+++ b/examples/aws_alb/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/aws_bucket/terraform.tf
+++ b/examples/aws_bucket/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/aws_codecommit/module.codecommit.tf
+++ b/examples/aws_codecommit/module.codecommit.tf
@@ -1,5 +1,4 @@
 module "codecommit" {
-  source          = "JamesWoolfenden/codecommit/aws"
-  version         = "v0.3.10"
+  source = "git::https://github.com/JamesWoolfenden/terraform-aws-codecommit.git?ref=170d66873a22e3c01dabc634b85646b48113122f" #v0.3.10
   repository_name = var.repository_name
 }

--- a/examples/aws_codecommit/terraform.tf
+++ b/examples/aws_codecommit/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/aws_instance/terraform.tf
+++ b/examples/aws_instance/terraform.tf
@@ -1,16 +1,16 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
     local = {
-      version = "2.0.0"
       source  = "hashicorp/local"
+      version = "2.8.0"
     }
     tls = {
-      version = "3.0.0"
       source  = "hashicorp/tls"
+      version = "4.2.1"
     }
   }
   required_version = ">= 0.14"

--- a/examples/aws_vpc/terraform.tf
+++ b/examples/aws_vpc/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/aws_vpc_subnet/terraform.tf
+++ b/examples/aws_vpc_subnet/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/basic-aws-auth/terraform.tf
+++ b/examples/basic-aws-auth/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/basic-gcp-auth/terraform.tf
+++ b/examples/basic-gcp-auth/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.50.0"
       source  = "hashicorp/google"
+      version = "7.30.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/gcp_vpc/terraform.tf
+++ b/examples/gcp_vpc/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.50.0"
       source  = "hashicorp/google"
+      version = "7.30.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/gcp_vpc_with_subnet/terraform.tf
+++ b/examples/gcp_vpc_with_subnet/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.50.0"
       source  = "hashicorp/google"
+      version = "7.30.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/iam_policy/data.aws_iam_policy_document.heredoc.tf
+++ b/examples/iam_policy/data.aws_iam_policy_document.heredoc.tf
@@ -1,7 +1,7 @@
 data "aws_iam_policy_document" "heredoc" {
-	# checkov:skip=CKV_AWS_109: Simplified example
-	# checkov:skip=CKV_AWS_111: Simplified example
-	# checkov:skip=CKV_AWS_107: Simplified example
+  # checkov:skip=CKV_AWS_109: Simplified example
+  # checkov:skip=CKV_AWS_111: Simplified example
+  # checkov:skip=CKV_AWS_107: Simplified example
   statement {
     actions = [
       "ec2:*",

--- a/examples/iam_policy/terraform.tf
+++ b/examples/iam_policy/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/inline_policy/terraform.tf
+++ b/examples/inline_policy/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">= 0.14"

--- a/examples/trust_relationship/terraform.tf
+++ b/examples/trust_relationship/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "3.27.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.