### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/examples/RDS-starter/module.host.tf
+++ b/examples/RDS-starter/module.host.tf
@@ -1,3 +1,3 @@
 module "host" {
-  source = "JamesWoolfenden/ip/http"
+  source = "git::https://github.com/JamesWoolfenden/terraform-http-ip.git?ref=2f3cef24e667fb840a3d3481f5a1aaa5a1ac7d28" #v0.3.14
 }

--- a/examples/aws_codecommit/module.codecommit.tf
+++ b/examples/aws_codecommit/module.codecommit.tf
@@ -1,4 +1,4 @@
 module "codecommit" {
-  source = "git::https://github.com/JamesWoolfenden/terraform-aws-codecommit.git?ref=170d66873a22e3c01dabc634b85646b48113122f" #v0.3.10
+  source = "git::https://github.com/JamesWoolfenden/terraform-aws-codecommit.git?ref=e4a7717c615eeb4f674d3919cc6a03317c2f5c3f" #v0.3.62
   repository_name = var.repository_name
 }


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.